### PR TITLE
Fix load-function for Preferences service

### DIFF
--- a/src/Services/Preferences.php
+++ b/src/Services/Preferences.php
@@ -5,4 +5,14 @@ namespace Rangka\Quickbooks\Services;
 use Rangka\Quickbooks\Client;
 
 class Preferences extends Service {
+  
+  /**
+     * Load a single item
+     *
+     * @return
+     */
+    public function load($id) {
+        return parent::get($this->getResourceName())->{$this->getEntityName()};
+    }
+  
 }


### PR DESCRIPTION
According to the Quickbooks documentation, the URI for the Preferences detail is "/company/:companyId/preferences".
The default load function generated the URI in the format "/company/:companyId/preferences/:companyId", resulting in an API error.

This PR fixes this.