### PR TITLE
Fixed static access error

### DIFF
--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -46,7 +46,7 @@ class Service extends Client {
         $response = parent::post($this->getResourceName(), $data);
 
         // Response has no root, send it back immediately.
-        if (!$this->responseHasRoot) {
+        if (!self::$responseHasRoot) {
             return $response;
         }
 
@@ -63,7 +63,7 @@ class Service extends Client {
         $response = parent::post($this->getResourceName() . '?operation=update', $data);
 
         // Response has no root, send it back immediately.
-        if (!$this->responseHasRoot) {
+        if (!self::$responseHasRoot) {
             return $response;
         }
 


### PR DESCRIPTION
The static property `Service::$responseHasRoot` is accessed dynamically with `$this->responseHasRoot` which results in errors like the following
```php
Accessing static property Rangka\Quickbooks\Services\Vendor::$responseHasRoot as non static
```

I changed every `$this->responseHasRoot` to  `self::$responseHasRoot` 