### PR TITLE
Fixed calling static variable non statically

### DIFF
--- a/src/Builders/Attachable.php
+++ b/src/Builders/Attachable.php
@@ -17,7 +17,7 @@ class Attachable extends Builder {
     /**
      * Upload attachments to Quickbooks.
      * 
-     * @return stdClass
+     * @return \stdClass
      */
     public function upload() {
         return $this->client->request('POST', 'upload', $this)->AttachableResponse;

--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -30,8 +30,8 @@ abstract class Builder implements BuilderContract {
     * Set's a value directly to root of array.
     * @param  string $name      Method name that was called.
     * @param  array  $arguments Arguments that was sent in with the call.
-    * @return void
-    */
+    * @return Builder
+     */
     public function __call($name, $arguments) {
         if (substr($name, 0, 3) == 'set') {
             $prop = substr($name, 3);
@@ -80,7 +80,7 @@ abstract class Builder implements BuilderContract {
     /**
     * Return data in JSON format.
     * 
-    * @return void
+    * @return string
     */
     public function toJson() {
         return json_encode($this->toArray());
@@ -89,7 +89,7 @@ abstract class Builder implements BuilderContract {
     /**
     * Format data in array.
     * 
-    * @return void
+    * @return array
     */
     public function toArray() {
         return $this->data;

--- a/src/Builders/Customer.php
+++ b/src/Builders/Customer.php
@@ -2,14 +2,13 @@
 
 namespace Rangka\Quickbooks\Builders;
 
-use Rangka\Quickbooks\Builders\Address;
-
 class Customer extends Builder {
     /**
      * Set a customer's full name
      * @param string $givenName  Customer's given (or first) name.
      * @param string $middleName Customer's middle name.
      * @param string $familyName Customer's family name (or surname).
+     * @return Customer
      */
     public function setName($givenName, $middleName = null, $familyName = null) {
         $this->data['GivenName'] = $givenName;
@@ -20,10 +19,11 @@ class Customer extends Builder {
     }
 
     /**
-    * Set customer's addresss.
-    * 
-    * @return void
-    */
+     * Set customer's address.
+     *
+     * @param Address $address
+     * @return Customer
+     */
     public function setBillingAddress(Address $address) {
         $this->data['BillAddr'] = $address->toArray();
 
@@ -31,10 +31,11 @@ class Customer extends Builder {
     }
 
     /**
-    * Set primary phone number. A shorted alias to setPrimaryPhone()
-    * 
-    * @return void
-    */
+     * Set primary phone number. A shorted alias to setPrimaryPhone()
+     *
+     * @param $phone
+     * @return Customer
+     */
     public function setPhone($phone) {
         $this->setPrimaryPhone($phone);
 
@@ -42,10 +43,11 @@ class Customer extends Builder {
     }
 
     /**
-    * Set primary phone number.
-    * 
-    * @return Rangka\Quickbooks\Builders\Customer
-    */
+     * Set primary phone number.
+     *
+     * @param $phone
+     * @return Customer
+     */
     public function setPrimaryPhone($phone) {
         $this->data['PrimaryPhone']['FreeFormNumber'] = $phone;
 
@@ -53,10 +55,11 @@ class Customer extends Builder {
     }
 
     /**
-    * Set mobile phone numner.
-    * 
-    * @return Rangka\Quickbooks\Builders\Customer
-    */
+     * Set mobile phone number.
+     *
+     * @param $phone
+     * @return Customer
+     */
     public function setMobilePhone($phone) {
         $this->data['Mobile']['FreeFormNumber'] = $phone;
 
@@ -64,10 +67,11 @@ class Customer extends Builder {
     }
 
     /**
-    * Set fax phone numner.
-    * 
-    * @return Rangka\Quickbooks\Builders\Customer
-    */
+     * Set fax phone number.
+     *
+     * @param $phone
+     * @return Customer
+     */
     public function setFaxPhone($phone) {
         $this->data['Fax']['FreeFormNumber'] = $phone;
 
@@ -75,10 +79,11 @@ class Customer extends Builder {
     }
 
     /**
-    * Set customer's email address.
-    * 
-    * @return Rangka\Quickbooks\Builders\Customer
-    */
+     * Set customer's email address.
+     *
+     * @param $email
+     * @return Customer
+     */
     public function setEmail($email) {
         $this->data['PrimaryEmailAddr']['Address'] = $email;
 

--- a/src/Builders/Invoice.php
+++ b/src/Builders/Invoice.php
@@ -12,7 +12,7 @@ class Invoice extends Builder {
     * Set Tax Code Reference ID
     *
     * @param string $code Tax Code Reference ID
-    * @return \Rangka\Quickbooks\Builders\Invoice
+    * @return Invoice
     */
     public function setTaxCodeRef($code) {
         $this->data['TxnTaxDetail']['TxnTaxCodeRef']['value'] = $code;
@@ -24,7 +24,7 @@ class Invoice extends Builder {
     * Set discount percentage.
     *
     * @param float $percent Discount percentage
-    * @return \Rangka\Quickbooks\Builders\Invoice
+    * @return Invoice
     */
     public function setDiscountPercent($percent) {
         $discount = $this->client->getItemBuilder()
@@ -40,7 +40,7 @@ class Invoice extends Builder {
     * Set discount value.
     *
     * @param float $percent Discount value
-    * @return \Rangka\Quickbooks\Builders\Invoice
+    * @return Invoice
     */
     public function setDiscountValue($value) {
         $discount = $this->client->getItemBuilder()
@@ -56,7 +56,7 @@ class Invoice extends Builder {
      * Set Billing Address by ID.
      *
      * @param  string $id Address ID
-     * @return \Rangka\Quickbooks\Builders\Invoice
+     * @return Invoice
      */
     public function setBillingAddressId($id) {
         $this->data['BillAddr']['Id'] = $id;
@@ -68,7 +68,7 @@ class Invoice extends Builder {
      * Set Shipping Address by ID.
      * 
      * @param  string $id Address ID
-     * @return \Rangka\Quickbooks\Builders\Invoice
+     * @return Invoice
      */
     public function setShippingAddressId($id) {
         $this->data['ShipAddr']['Id'] = $id;
@@ -82,7 +82,7 @@ class Invoice extends Builder {
      *
      * @param  float    $amount Amount to be taxed.
      * @param  string   $id     TaxRateRef ID.
-     * @return \Rangka\Quickbooks\Builders\Invoice
+     * @return Invoice
      */
     public function addTaxableAmount($amount, $id) {
         $this->data['TxnTaxDetail']['TaxLine'] = [

--- a/src/Builders/Item.php
+++ b/src/Builders/Item.php
@@ -11,7 +11,7 @@ class Item extends Builder {
     * be set as false.
     *
     * @param  string $type Item's type. Either `Inventory`, `NonInventory` or `Service`.
-    * @return Rangka\Quickbooks\Builders\Item
+    * @return Item
     */
     public function setType($type) {
         parent::setType($type);
@@ -27,7 +27,7 @@ class Item extends Builder {
     * @param string $type   Type of Account. Either 'Asset', 'Income' or 'Expense'.
     * @param int    $id     ID of Account Ref.
     * @param string $name   Name of Account Ref.
-    * @return void
+    * @return Item
     */
     public function setAccountRef($type, $id, $name = '') {
         $this->data[$type . 'AccountRef'] = [
@@ -43,7 +43,7 @@ class Item extends Builder {
     *
     * @param int    $id     ID of Account Ref.
     * @param string $name   Name of Account Ref.
-    * @return Rangka\Quickbooks\Builders\Item
+    * @return Item
     */
     public function setIncomeAccountRef($id, $name = '') {
         $this->setAccountRef('Income', $id, $name);
@@ -56,7 +56,7 @@ class Item extends Builder {
     *
     * @param int    $id     ID of Account Ref.
     * @param string $name   Name of Account Ref.
-    * @return Rangka\Quickbooks\Builders\Item
+    * @return Item
     */
     public function setExpenseAccountRef($id, $name = '') {
         $this->setAccountRef('Expense', $id, $name);
@@ -69,7 +69,7 @@ class Item extends Builder {
     *
     * @param int    $id     ID of Account Ref.
     * @param string $name   Name of Account Ref.
-    * @return Rangka\Quickbooks\Builders\Item
+    * @return Item
     */
     public function setAssetAccountRef($id, $name = '') {
         $this->setAccountRef('Asset', $id, $name);
@@ -82,7 +82,7 @@ class Item extends Builder {
     * Alias for `setQtyOnHand`.
     *
     * @param integer $amount Amount of Item
-    * @return Rangka\Quickbooks\Builders\Item
+    * @return Item
     */
     public function setQuantity($amount) {
         $this->data['QtyOnHand'] = $amount;

--- a/src/Builders/Items/Invoice.php
+++ b/src/Builders/Items/Invoice.php
@@ -7,7 +7,7 @@ class Invoice extends Item {
     * Set Item's name. This is not needed if name is set through setItem()
     *
     * @param string $name Name of Item.
-    * @return \Rangka\Quickbooks\Builders\InvoiceItem
+    * @return \Rangka\Quickbooks\Builders\Items\Invoice
     */
     public function setUnitPrice($name) {
         $this->data[$this->data['DetailType']]['UnitPrice'] = $name;
@@ -19,7 +19,7 @@ class Invoice extends Item {
     * Set Item Reference (from Products & Services) associated to this Item.
     *
     * @param string $id Item ID
-    * @return \Rangka\Quickbooks\Builders\InvoiceItem
+    * @return \Rangka\Quickbooks\Builders\Items\Invoice
     */
     public function setItemRef($id) {
         $this->data[$this->data['DetailType']]['ItemRef']['value'] = $id;
@@ -31,7 +31,7 @@ class Invoice extends Item {
     * Set Item's quantity.
     *
     * @param integer $quantity Item quantity.
-    * @return \Rangka\Quickbooks\Builders\InvoiceItem
+    * @return \Rangka\Quickbooks\Builders\Items\Invoice
     */
     public function setQuantity($quantity) {
         $this->data[$this->data['DetailType']]['Qty'] =  $quantity;
@@ -42,7 +42,7 @@ class Invoice extends Item {
     /**
     * Set this Item as Sales Item.
     * 
-    * @return \Rangka\Quickbooks\Builders\InvoiceItem
+    * @return \Rangka\Quickbooks\Builders\Items\Invoice
     */
     public function asSalesItem() {
         $this->setDetailType('SalesItemLineDetail');
@@ -53,7 +53,7 @@ class Invoice extends Item {
     /**
     * Set this Item as Discount.
     * 
-    * @return \Rangka\Quickbooks\Builders\InvoiceItem
+    * @return \Rangka\Quickbooks\Builders\Items\Invoice
     */
     public function asDiscount() {
         $this->setDetailType('DiscountLineDetail');
@@ -65,7 +65,7 @@ class Invoice extends Item {
     * Set discount's percentage value.
     *
     * @param float $percent Discount percentage.
-    * @return \Rangka\Quickbooks\Builders\InvoiceItem
+    * @return \Rangka\Quickbooks\Builders\Items\Invoice
     */
     public function setPercent($percent) {
         $this->data[$this->data['DetailType']]['PercentBased'] = true;
@@ -78,7 +78,7 @@ class Invoice extends Item {
     * Set discount's value.
     *
     * @param float $value Discount value.
-    * @return \Rangka\Quickbooks\Builders\InvoiceItem
+    * @return \Rangka\Quickbooks\Builders\Items\Invoice
     */
     public function setValue($value) {
         $this->setAmount($value);
@@ -90,9 +90,9 @@ class Invoice extends Item {
     /**
     * Set this item to be taxable.
     *
-    * @param  boolean   $taxable    Set to TRUE to make it taxable or FALSE otherwise. TRUE by default.
-    * @param  id        $id         TaxCode ID.
-    * @return \Rangka\Quickbooks\Builders\InvoiceItem
+    * @param  boolean $taxable Set to TRUE to make it taxable or FALSE otherwise. TRUE by default.
+    * @param  mixed $id TaxCode ID.
+    * @return \Rangka\Quickbooks\Builders\Items\Invoice
     */
     public function isTaxable($taxable = true, $id = 'TAX') {
         if ($taxable) {

--- a/src/Builders/Items/Payment.php
+++ b/src/Builders/Items/Payment.php
@@ -6,7 +6,9 @@ class Payment extends Item {
     /**
      * Set an ID and Type of this Payment Item.
      *
-     * @return \Rangka\Quickbooks\Builders\Items\Payment
+     * @param $type
+     * @param $id
+     * @return Payment
      */
     protected function setId($type, $id) {
         $this->data['LinkedTxn'][] = [
@@ -19,8 +21,9 @@ class Payment extends Item {
 
     /**
      * Set Expense ID for this Payment Item
-     * 
-     * @return \Rangka\Quickbooks\Builders\Items\Payment
+     *
+     * @param $id
+     * @return Payment
      */
     public function setExpenseId($id) {
         return $this->setId('Expense', $id);
@@ -28,8 +31,9 @@ class Payment extends Item {
 
     /**
      * Set Check ID for this Payment Item
-     * 
-     * @return \Rangka\Quickbooks\Builders\Items\Payment
+     *
+     * @param $id
+     * @return Payment
      */
     public function setCheckId($id) {
         return $this->setId('Check', $id);
@@ -37,8 +41,9 @@ class Payment extends Item {
 
     /**
      * Set CreditCardCredit ID for this Payment Item
-     * 
-     * @return \Rangka\Quickbooks\Builders\Items\Payment
+     *
+     * @param $id
+     * @return Payment
      */
     public function setCreditCardCreditId($id) {
         return $this->setId('CreditCardCredit', $id);
@@ -46,8 +51,9 @@ class Payment extends Item {
 
     /**
      * Set JournalEntry ID for this Payment Item
-     * 
-     * @return \Rangka\Quickbooks\Builders\Items\Payment
+     *
+     * @param $id
+     * @return Payment
      */
     public function setJournalEntryId($id) {
         return $this->setId('JournalEntry', $id);
@@ -55,8 +61,9 @@ class Payment extends Item {
 
     /**
      * Set CreditMemo ID for this Payment Item
-     * 
-     * @return \Rangka\Quickbooks\Builders\Items\Payment
+     *
+     * @param $id
+     * @return Payment
      */
     public function setCreditMemoId($id) {
         return $this->setId('CreditMemo', $id);
@@ -64,8 +71,9 @@ class Payment extends Item {
 
     /**
      * Set Invoice ID for this Payment Item
-     * 
-     * @return \Rangka\Quickbooks\Builders\Items\Payment
+     *
+     * @param $id
+     * @return Payment
      */
     public function setInvoiceId($id) {
         return $this->setId('Invoice', $id);

--- a/src/Builders/Payment.php
+++ b/src/Builders/Payment.php
@@ -12,7 +12,7 @@ class Payment extends Builder {
      * Alias to setTotalAmt()
      *
      * @param  float    $amount     Payment amount
-     * @return \Rangka\Quickbooks\Builders\Payment
+     * @return Payment
      */
     public function setAmount($amount) {
         return $this->setTotalAmt($amount);
@@ -22,7 +22,7 @@ class Payment extends Builder {
      * Alias to setPaymentRefNum()
      *
      * @param  string $num Reference number.
-     * @return \Rangka\Quickbooks\Builders\Payment
+     * @return Payment
      */
     public function setPaymentReference($num) {
         return $this->setPaymentRefNum($num);
@@ -32,7 +32,7 @@ class Payment extends Builder {
      * Set payment method by ID.
      *
      * @param  string $id Payment Method ID.
-     * @return \Rangka\Quickbooks\Builders\Payment
+     * @return Payment
      */
     public function setPaymentMethod($id) {
         $this->data['PaymentMethodRef']['value'] = $id;
@@ -44,7 +44,7 @@ class Payment extends Builder {
      * Set Deposit Account by ID.
      *
      * @param  string $id Account ID.
-     * @return \Rangka\Quickbooks\Builders\Payment
+     * @return Payment
      */
     public function setDepositAccount($id)
     {
@@ -57,7 +57,7 @@ class Payment extends Builder {
      * Alias to setTxnDate()
      *
      * @param  string $date Date in format YYYY-MM-DD (2016-12-30)
-     * @return \Rangka\Quickbooks\Builders\Payment
+     * @return Payment
      */
     public function setTransactionDate($date) {
         return $this->setTxnDate($date);

--- a/src/Builders/Traits/HasCustomer.php
+++ b/src/Builders/Traits/HasCustomer.php
@@ -7,7 +7,7 @@ trait HasCustomer {
     * Set Customer's ID
     *
     * @param integer $id Customer's Quickbooks ID
-    * @return \Rangka\Quickbooks\Builders\Invoice
+    * @return $this
     */
     public function setCustomer($id) {
         $this->data['CustomerRef']['value'] = $id;

--- a/src/Builders/Traits/Itemizable.php
+++ b/src/Builders/Traits/Itemizable.php
@@ -5,11 +5,12 @@ namespace Rangka\Quickbooks\Builders\Traits;
 use Rangka\Quickbooks\Builders\Items\Item;
 
 trait Itemizable {
+
     /**
     * Add an item.
     *
-    * @param \Rangka\Quickbooks\Builders\Items\Item    $item  Object that extends from Items\Item.
-    * @return Current object ($this).
+    * @param Item $item  Object that extends from Items\Item.
+    * @return $this
     */
     public function addItem(Item $item) {
         $this->data['Line'][] = $item->toArray();
@@ -20,7 +21,7 @@ trait Itemizable {
     /**
      * Get Itemized Item Builder.
      * 
-     * @return \Rangka\Quickbooks\Builders\Items\Item
+     * @return Item
      */
     public function getItemBuilder() {
         $class = '\Rangka\Quickbooks\Builders\Items\\' . $this->getEntityName();

--- a/src/Builders/Traits/UseMultipart.php
+++ b/src/Builders/Traits/UseMultipart.php
@@ -30,11 +30,11 @@ trait UseMultipart {
 
     /**
      * Add a part.
-     * 
-     * @param string $name     Name of this field.
+     *
+     * @param string $name Name of this field.
      * @param string $filePath Path to file.
-     * @param string $fileName File name. Optional.
-     * 
+     * @param string|null $fileType
+     * @param string|null $fileName File name. Optional.
      * @return void
      */
     public function addFilePart($name, $filePath, $fileType = null, $fileName = null) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 namespace Rangka\Quickbooks;
 
 use GuzzleHttp\Client as Guzzle;
+use Psr\Http\Message\StreamInterface;
 use Rangka\Quickbooks\Builders\Builder;
 use Rangka\Quickbooks\Builders\Traits\UseMultipart;
 
@@ -155,7 +156,7 @@ class Client {
     /**
     * Request from Quickbooks.
     * 
-    * @return 
+    * @return StreamInterface
     */
     public function request($method, $url, $body = [], $headers = []) {
         $url      = trim($url, '/');
@@ -205,10 +206,12 @@ class Client {
     }
 
     /**
-    * Make a GET request.
-    * 
-    * @return void
-    */
+     * Make a GET request.
+     *
+     * @param $url
+     * @param array $body
+     * @return string
+     */
     public function get($url, $body = []) {
         return $this->request('GET', $url, $body);
     }
@@ -216,7 +219,7 @@ class Client {
     /**
     * Make a POST request.
     * 
-    * @return void
+    * @return string
     */
     public function post($url, $body = [], $headers = []) {
         return $this->request('POST', $url, $body, $headers);

--- a/src/Connect.php
+++ b/src/Connect.php
@@ -41,24 +41,24 @@ class Connect extends Client {
     protected $callback_url;
 
     /**
-    * Constructor
-    * @return void
-    */
+     * Connect constructor.
+     * @param array $options
+     */
     public function __construct($options = []) {
-        parent::__construct($options);
+        parent::__construct();
 
         if (isset($options['callback_url']))
             $this->callback_url = $options['callback_url'];
     }
 
     /**
-    * Get token from QuickBooks.
-    * 
-    * @return array
-    */
+     * Get token from QuickBooks.
+     * @return array
+     * @throws \Exception
+     */
     public function requestAccess() {
         if(self::$oauth_token)
-            throw new \Exception('Quickbooks has been connected. Please disconnect before proceeding.');
+            throw new \Exception('QuickBooks has been connected. Please disconnect before proceeding.');
         
         $res = $this->request('GET', self::URL_REQUEST_TOKEN, [
             'oauth_callback' => $this->callback_url
@@ -75,10 +75,10 @@ class Connect extends Client {
     }
 
     /**
-    * Reconnect to Quickbooks to get a fresh token.
-    * 
-    * @return array
-    */
+     * Reconnect to QuickBooks to get a fresh token.
+     * @return array
+     * @throws \Exception
+     */
     public function reconnect() {
         $signed = $this->sign('GET', self::URL_RECONNECT, [
             'oauth_token' => self::$oauth_token
@@ -106,10 +106,11 @@ class Connect extends Client {
     }
 
     /**
-    * Connect to Quickbooks and save OAuth token for future usage.
-    * 
-    * @return array
-    */
+     * Connect to QuickBooks and save OAuth token for future usage.
+     *
+     * @param $params
+     * @return array
+     */
     public function connect($params) {
         $response = $this->request('GET', self::URL_ACCESS_TOKEN, [
             'oauth_token'    => $params['oauth_token'], 
@@ -129,10 +130,13 @@ class Connect extends Client {
     }
 
     /**
-    * Request from Quickbooks.
-    * 
-    * @return array
-    */
+     * Request from QuickBooks.
+     * @param $method
+     * @param $url
+     * @param array $params
+     * @param array $headers
+     * @return mixed|\Psr\Http\Message\ResponseInterface
+     */
     public function request($method, $url, $params = [], $headers = []) {
         $signed = $this->sign('GET', $url, $params);
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -103,7 +103,7 @@ class Query {
      * Set entity to request.
      *
      * @param    string                      $entity     Entity name.
-     * @return   \Rangka\Quickbooks\Query
+     * @return   Query
      */
     public function entity($entity) {
         $this->entity = $entity;
@@ -115,7 +115,7 @@ class Query {
      * Set properties to retrieve
      *
      * @param    array[string]               $properties     Array of properties.
-     * @return   \Rangka\Quickbooks\Query
+     * @return   Query
      */
     public function select($properties) {
         if (!is_array($properties))
@@ -132,7 +132,7 @@ class Query {
      * @param    string                      $property       Property name.
      * @param    string                      $operator       Operator for constraining. Either `<`, `<=`, `>`, `>=`, `=`, `!=`, `LIKE`
      * @param    string                      $constraint     Value of constraint
-     * @return   \Rangka\Quickbooks\Query
+     * @return   Query
      */
     public function where($property, $operator, $constraint) {
         $this->where[] = $property . " " . $operator . " '" . $constraint . "'";
@@ -144,7 +144,7 @@ class Query {
      * Set a where constraint for a TRUE boolean.
      *
      * @param    string                      $property       Property name.
-     * @return   \Rangka\Quickbooks\Query
+     * @return   Query
      */
     public function whereTrue($property) {
         $this->where[] = $property . " = true";
@@ -156,7 +156,7 @@ class Query {
      * Set a where constraint for a FALSE boolean.
      *
      * @param    string                      $property       Property name.
-     * @return   \Rangka\Quickbooks\Query
+     * @return   Query
      */
     public function whereFalse($property) {
         $this->where[] = $property . " = false";
@@ -167,9 +167,9 @@ class Query {
     /**
      * Set a an IN constraint.
      *
-     * @param    string    $property       Property name.
-     * @param    array     $array          Array of IDs. 
-     * @return   void
+     * @param string $property Property name.
+     * @param array $ids Array of IDs.
+     * @return Query
      */
     public function in($property, $ids)
     {
@@ -183,7 +183,7 @@ class Query {
      *
      * @param string $property Property name.
      * @param string $constraint Constraint value.
-     * @return \Rangka\Quickbooks\Query
+     * @return Query
      */
     public function like($property, $constraint) {
         return $this->where($property, 'LIKE', $constraint);
@@ -194,7 +194,7 @@ class Query {
      *
      * @param  integer $start Start position.
      * @param  integer $length Number of entities to fetch.
-     * @return void
+     * @return Query
      */
     public function paginate($start, $length)
     {
@@ -211,7 +211,7 @@ class Query {
      *
      * @param  string $property Property to be used for sorting.
      * @param  string $order    Ordering. Either "ASC" or "DESC". Optional.
-     * @return void
+     * @return Query
      */
     public function orderBy($property, $order = null)
     {
@@ -224,9 +224,10 @@ class Query {
     }
 
     /**
-     * Get data from Quickbooks
-     * 
-     * @return array
+     * Get data from QuickBooks
+     *
+     * @return array|\stdClass
+     * @throws \Exception
      */
     public function get() {
         $data = $this->client->get('query?query=' . rawurlencode($this));

--- a/src/Services/Account.php
+++ b/src/Services/Account.php
@@ -2,9 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Builders\Address;
-use Rangka\Quickbooks\Client;
-
 class Account extends Service {
     
 }

--- a/src/Services/Attachable.php
+++ b/src/Services/Attachable.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class Attachable extends Service {
     
 }

--- a/src/Services/Bill.php
+++ b/src/Services/Bill.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class Bill extends Service {

--- a/src/Services/BillPayment.php
+++ b/src/Services/BillPayment.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class BillPayment extends Service {
     
 }

--- a/src/Services/CompanyInfo.php
+++ b/src/Services/CompanyInfo.php
@@ -2,7 +2,5 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class CompanyInfo extends Service {
 }

--- a/src/Services/CreditMemo.php
+++ b/src/Services/CreditMemo.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class CreditMemo extends Service {

--- a/src/Services/Customer.php
+++ b/src/Services/Customer.php
@@ -3,14 +3,13 @@
 namespace Rangka\Quickbooks\Services;
 
 use Rangka\Quickbooks\Builders\Address;
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class Customer extends Service {
 	use Attachable;
 
     /**
-    * Get an instance of Address Builder to build Adrdress
+    * Get an instance of Address Builder to build Address
     * @return \Rangka\Quickbooks\Builders\Address
     */
     public function getAddressBuilder() {

--- a/src/Services/Department.php
+++ b/src/Services/Department.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class Department extends Service {
     
 }

--- a/src/Services/Deposit.php
+++ b/src/Services/Deposit.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class Deposit extends Service {

--- a/src/Services/Employee.php
+++ b/src/Services/Employee.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class Employee extends Service {
     
 }

--- a/src/Services/Estimate.php
+++ b/src/Services/Estimate.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class Estimate extends Service {

--- a/src/Services/Invoice.php
+++ b/src/Services/Invoice.php
@@ -2,8 +2,7 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Builders\InvoiceItem;
-use Rangka\Quickbooks\Client;
+use Psr\Http\Message\StreamInterface;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 use Rangka\Quickbooks\Services\Traits\Itemizable;
 
@@ -15,7 +14,7 @@ class Invoice extends Service {
      *
      * @param string $id Invoice ID.
      * 
-     * @return \GuzzleHttp\Psr7\Stream
+     * @return StreamInterface
      */
     public function downloadPdf($id) {
         return $this->request('GET', $this->getResourceName() . '/' . $id . '/pdf', [], [
@@ -29,7 +28,7 @@ class Invoice extends Service {
      * @param string $id    Invoice ID.
      * @param string $email Email to be sent to.
      * 
-     * @return \GuzzleHttp\Psr7\Stream
+     * @return StreamInterface
      */
     public function send($id, $email = null) {
         $url = $this->getResourceName() . '/' . $id . '/send';

--- a/src/Services/Item.php
+++ b/src/Services/Item.php
@@ -2,7 +2,5 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class Item extends Service {
 }

--- a/src/Services/JournalEntry.php
+++ b/src/Services/JournalEntry.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class JournalEntry extends Service {

--- a/src/Services/Payment.php
+++ b/src/Services/Payment.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 use Rangka\Quickbooks\Services\Traits\Itemizable;
 

--- a/src/Services/PaymentMethod.php
+++ b/src/Services/PaymentMethod.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class PaymentMethod extends Service {
     
 }

--- a/src/Services/Preferences.php
+++ b/src/Services/Preferences.php
@@ -2,13 +2,12 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class Preferences extends Service {
-  
-  /**
+
+    /**
      * Load a single item
      *
+     * @param $id
      * @return
      */
     public function load($id) {

--- a/src/Services/Purchase.php
+++ b/src/Services/Purchase.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class Purchase extends Service {

--- a/src/Services/PurchaseOrder.php
+++ b/src/Services/PurchaseOrder.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class PurchaseOrder extends Service {

--- a/src/Services/QBClass.php
+++ b/src/Services/QBClass.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class QBClass extends Service {
     /**
      * Resource endpoint of this service.

--- a/src/Services/RefundReceipt.php
+++ b/src/Services/RefundReceipt.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class RefundReceipt extends Service {

--- a/src/Services/Reports.php
+++ b/src/Services/Reports.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class Reports extends Service {
     
 }

--- a/src/Services/SalesReceipt.php
+++ b/src/Services/SalesReceipt.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class SalesReceipt extends Service {

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -2,6 +2,7 @@
 
 namespace Rangka\Quickbooks\Services;
 
+use Rangka\Quickbooks\Builders\Builder;
 use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Query;
 
@@ -14,7 +15,7 @@ class Service extends Client {
     protected static $resource;
 
     /**
-     * Entity name of this service. Must correspond to actual object type in Quickbooks.
+     * Entity name of this service. Must correspond to actual object type in QuickBooks.
      * 
      * @var string
      */
@@ -28,25 +29,25 @@ class Service extends Client {
     protected $responseHasRoot = true;
 
     /**
-    * Load a single item
-    * 
-    * @return 
-    */
+     * Load a single item.
+     * @param $id
+     * @return mixed
+     */
     public function load($id) {
         return parent::get($this->getResourceName() . '/' . $id)->{$this->getEntityName()};
     }
 
     /**
-    * Create a single item
-    * 
-    * @param array $data Item information
-    * @return 
-    */
+     * Create a single item
+     *
+     * @param array $data Item information
+     * @return string
+     */
     public function create($data) {
         $response = parent::post($this->getResourceName(), $data);
 
         // Response has no root, send it back immediately.
-        if (!static::$responseHasRoot) {
+        if (!$this->responseHasRoot) {
             return $response;
         }
 
@@ -54,16 +55,16 @@ class Service extends Client {
     }
 
     /**
-    * Update an entity.
-    *
-    * @param array $data Item information.
-    * @return void
-    */
+     * Update an entity.
+     *
+     * @param array $data Item information.
+     * @return string
+     */
     public function update($data) {
         $response = parent::post($this->getResourceName() . '?operation=update', $data);
 
         // Response has no root, send it back immediately.
-        if (!static::$responseHasRoot) {
+        if (!$this->responseHasRoot) {
             return $response;
         }
 
@@ -74,7 +75,6 @@ class Service extends Client {
     * Delete an entity.
     *
     * @param array $data Item information.
-    * @return void
     */
     public function delete($data) {
         return parent::post($this->getResourceName() . '?operation=delete', [
@@ -84,11 +84,9 @@ class Service extends Client {
     }
 
     /**
-    * Query quickbooks. Use Query to construct the query itself.
-    *
-    * @param \Rangka\Quickbooks\Query   $query      Query object
-    * @return object
-    */
+     * Query QuickBooks. Use Query to construct the query itself.
+     * @return object
+     */
     public function query() {
         return (new Query($this))->entity($this->getEntityName());
     }
@@ -105,7 +103,7 @@ class Service extends Client {
     /**
     * Get builder instance to construct entity data.
     *
-    * @return \Rangka\Quickbooks\Builders\Builder
+    * @return Builder
     */
     public function getBuilder() {
         $class = '\Rangka\Quickbooks\Builders\\' . $this->getClassName();

--- a/src/Services/Service.php
+++ b/src/Services/Service.php
@@ -25,7 +25,7 @@ class Service extends Client {
      *
      * @var boolean
      */
-    protected static $responseHasRoot = true;
+    protected $responseHasRoot = true;
 
     /**
     * Load a single item

--- a/src/Services/TaxAgency.php
+++ b/src/Services/TaxAgency.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class TaxAgency extends Service {
     
 }

--- a/src/Services/TaxCode.php
+++ b/src/Services/TaxCode.php
@@ -2,7 +2,5 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class TaxCode extends Service {
 }

--- a/src/Services/TaxRate.php
+++ b/src/Services/TaxRate.php
@@ -2,7 +2,5 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class TaxRate extends Service {
 }

--- a/src/Services/TaxService.php
+++ b/src/Services/TaxService.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class TaxService extends Service {
     /**
      * Resource endpoint of this service.

--- a/src/Services/TaxService.php
+++ b/src/Services/TaxService.php
@@ -17,5 +17,5 @@ class TaxService extends Service {
      *
      * @var boolean
      */
-    protected static $responseHasRoot = false;
+    protected $responseHasRoot = false;
 }

--- a/src/Services/Term.php
+++ b/src/Services/Term.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class Term extends Service {
     
 }

--- a/src/Services/TimeActivity.php
+++ b/src/Services/TimeActivity.php
@@ -2,8 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
-
 class TimeActivity extends Service {
     
 }

--- a/src/Services/Traits/Attachable.php
+++ b/src/Services/Traits/Attachable.php
@@ -5,20 +5,23 @@ namespace Rangka\Quickbooks\Services\Traits;
 use Rangka\Quickbooks\Services\Attachable as AttachableService;
 
 trait Attachable {
+
     /**
      * Attach attachments to an Entity.
      *
-     * @param int     $id              ID of entity.
-     * @param array   $file            Array of files each consists of:
+     * @param int $id ID of entity.
+     * @param array $files Array of files each consists of:
      *                                   - 'path' - Path to file. Required.
      *                                   - 'name' - File name. Optional.
      *                                   - 'type' - File type. Optional.
-     * @param boolean $includeOnSend   Attach to Email. Optional.
-     * 
-     * @return \Rangka\Quickbooks\Builders\ItemizedItem
+     * @param boolean $includeOnSend Attach to Email. Optional.
+     *
+     * @return \stdClass
      */
     public function attach($id, $files, $includeOnSend = null) {
         $service = new AttachableService;
+
+        /** @var \Rangka\Quickbooks\Builders\Attachable $builder */
         $builder = $service->getBuilder();
 
         foreach ($files as $file) {

--- a/src/Services/Traits/Itemizable.php
+++ b/src/Services/Traits/Itemizable.php
@@ -6,7 +6,7 @@ trait Itemizable {
     /**
      * Get Itemized Item Builder.
      * 
-     * @return \Rangka\Quickbooks\Builders\ItemizedItem
+     * @return \Rangka\Quickbooks\Builders\Items\Invoice|\Rangka\Quickbooks\Builders\Items\Payment
      */
     public function getItemBuilder() {
         $class = '\Rangka\Quickbooks\Builders\Items\\' . $this->getEntityName();

--- a/src/Services/Transfer.php
+++ b/src/Services/Transfer.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class Transfer extends Service {

--- a/src/Services/Vendor.php
+++ b/src/Services/Vendor.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class Vendor extends Service {

--- a/src/Services/VendorCredit.php
+++ b/src/Services/VendorCredit.php
@@ -2,7 +2,6 @@
 
 namespace Rangka\Quickbooks\Services;
 
-use Rangka\Quickbooks\Client;
 use Rangka\Quickbooks\Services\Traits\Attachable;
 
 class VendorCredit extends Service {


### PR DESCRIPTION
The $responseHasRoot variable was declared statically, but called non statically.

Since it's overridden in TaxService to be false I presumed it should be a non static variable.
This gets rid of PHP warnings.